### PR TITLE
refactor: add assertions

### DIFF
--- a/src/main/java/duke/command/AddCommand.java
+++ b/src/main/java/duke/command/AddCommand.java
@@ -21,6 +21,7 @@ public abstract class AddCommand extends Command {
      */
     public AddCommand(String command, Task task) {
         super(command);
+        assert(!command.isEmpty());
         this.task = task;
     }
 

--- a/src/main/java/duke/command/AddDeadlineCommand.java
+++ b/src/main/java/duke/command/AddDeadlineCommand.java
@@ -12,6 +12,7 @@ import duke.task.Deadline;
 public class AddDeadlineCommand extends AddCommand {
     private AddDeadlineCommand(String command, Deadline deadline) {
         super(command, deadline);
+        assert(command.startsWith("deadline"));
     }
 
     /**
@@ -24,6 +25,8 @@ public class AddDeadlineCommand extends AddCommand {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static AddDeadlineCommand of(String command) throws IllegalArgumentException {
+        assert(command.startsWith("deadline"));
+
         boolean isDone = command.contains("/done");
         if (isDone) {
             command = command.replace("/done", "");

--- a/src/main/java/duke/command/AddEventCommand.java
+++ b/src/main/java/duke/command/AddEventCommand.java
@@ -12,6 +12,7 @@ import duke.task.Event;
 public class AddEventCommand extends AddCommand {
     private AddEventCommand(String command, Event event) {
         super(command, event);
+        assert(command.startsWith("event"));
     }
 
     /**
@@ -24,6 +25,8 @@ public class AddEventCommand extends AddCommand {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static AddEventCommand of(String command) throws IllegalArgumentException {
+        assert(command.startsWith("event"));
+
         boolean isDone = command.contains("/done");
         if (isDone) {
             command = command.replace("/done", "");

--- a/src/main/java/duke/command/AddTodoCommand.java
+++ b/src/main/java/duke/command/AddTodoCommand.java
@@ -8,6 +8,7 @@ import duke.task.Todo;
 public class AddTodoCommand extends AddCommand {
     private AddTodoCommand(String command, Todo todo) {
         super(command, todo);
+        assert(command.startsWith("todo"));
     }
 
     /**
@@ -19,6 +20,8 @@ public class AddTodoCommand extends AddCommand {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static AddTodoCommand of(String command) throws IllegalArgumentException {
+        assert(command.startsWith("todo"));
+
         boolean isDone = command.contains("/done");
         if (isDone) {
             command = command.replace("/done", "");

--- a/src/main/java/duke/command/ByeCommand.java
+++ b/src/main/java/duke/command/ByeCommand.java
@@ -15,6 +15,7 @@ public class ByeCommand extends Command {
      */
     public ByeCommand(String command) {
         super(command);
+        assert(command == "bye");
     }
 
     @Override

--- a/src/main/java/duke/command/Command.java
+++ b/src/main/java/duke/command/Command.java
@@ -27,6 +27,7 @@ public abstract class Command {
      * @param command input string from user.
      */
     public Command(String command) {
+        assert(!command.isEmpty());
         this.command = command;
     }
 

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -18,6 +18,8 @@ public class DeleteCommand extends Command {
 
     private DeleteCommand(String command, Task task, int taskIndex, TaskList taskList) {
         super(command);
+        assert(command.startsWith("delete"));
+
         this.task = task;
         this.taskIndex = taskIndex;
         this.taskList = taskList;
@@ -34,6 +36,7 @@ public class DeleteCommand extends Command {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static DeleteCommand of(String command, TaskList taskList) throws IllegalArgumentException {
+        assert(command.startsWith("delete"));
         int taskIndex;
         try {
             taskIndex = Parser.getTaskIndex(command);

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -12,6 +12,7 @@ public class FindCommand extends Command {
 
     private FindCommand(String command, String keyword) {
         super(command);
+        assert(command.startsWith("find"));
         this.keyword = keyword;
     }
 
@@ -25,6 +26,7 @@ public class FindCommand extends Command {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static FindCommand of(String command) throws IllegalArgumentException {
+        assert(command.startsWith("find"));
         String keyword = command.replace("find", "").trim();
         if (keyword.isEmpty()) {
             throw new IllegalArgumentException("🙁 OOPS!!! Provide a keyword to find tasks.\n");

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -15,6 +15,7 @@ public class ListCommand extends Command {
      */
     public ListCommand(String command) {
         super(command);
+        assert(command == "list");
     }
 
     @Override

--- a/src/main/java/duke/command/UpdateCommand.java
+++ b/src/main/java/duke/command/UpdateCommand.java
@@ -18,6 +18,7 @@ public abstract class UpdateCommand extends Command {
      */
     public UpdateCommand(String command, Task task, int taskIndex) {
         super(command);
+        assert(!command.isEmpty());
         this.task = task;
         this.taskIndex = taskIndex;
     }

--- a/src/main/java/duke/command/UpdateMarkCommand.java
+++ b/src/main/java/duke/command/UpdateMarkCommand.java
@@ -14,6 +14,7 @@ import duke.task.Task;
 public class UpdateMarkCommand extends UpdateCommand {
     private UpdateMarkCommand(String command, Task task, int taskIndex) {
         super(command, task, taskIndex);
+        assert(command.startsWith("mark"));
     }
 
     /**
@@ -27,6 +28,7 @@ public class UpdateMarkCommand extends UpdateCommand {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static UpdateMarkCommand of(String command, TaskList taskList) throws IllegalArgumentException {
+        assert(command.startsWith("mark"));
         int taskIndex;
         try {
             taskIndex = Parser.getTaskIndex(command);

--- a/src/main/java/duke/command/UpdateUnmarkCommand.java
+++ b/src/main/java/duke/command/UpdateUnmarkCommand.java
@@ -14,6 +14,7 @@ import duke.task.Task;
 public class UpdateUnmarkCommand extends UpdateCommand {
     private UpdateUnmarkCommand(String command, Task task, int taskIndex) {
         super(command, task, taskIndex);
+        assert(command.startsWith("unmark"));
     }
 
     /**
@@ -27,6 +28,7 @@ public class UpdateUnmarkCommand extends UpdateCommand {
      * @throws IllegalArgumentException if input string from user is invalid.
      */
     public static UpdateUnmarkCommand of(String command, TaskList taskList) throws IllegalArgumentException {
+        assert(command.startsWith("unmark"));
         int taskIndex;
         try {
             taskIndex = Parser.getTaskIndex(command);


### PR DESCRIPTION
Classes in the command package accept any string as the command when they are initialised.

This could result in a wrong command being created if the wrong constructor is called for a certain command string (e.g. a DeleteCommand could possibly be created for "todo abc", which should be an AddTodoCommand).

Assertions are added to all factory methods and constructors that assert what their command strings should start with or be equal to.

Since Parser should already ensure that the correct constructors and factory methods are called for a certain command string, asserts ensure that this does not change in future updates in code.